### PR TITLE
Fix: Return if value in setter is undefined or not, rather than the v…

### DIFF
--- a/lib/weak.js
+++ b/lib/weak.js
@@ -101,7 +101,7 @@ const proxyHandler = {
   set(info, key, value) {
     const target = info.target;
     if (target !== undefined) target[key] = value;
-    return value;
+    return true;
   },
   deleteProperty(info, key) {
     const target = info.target;


### PR DESCRIPTION
…alue.

To avoid a false/fail return for setter when setting falsy values