### PR TITLE
fix: depend on published `node-addon-api`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '4' ] || (echo 'Some prebuilds are missing'; exit 1))"
   },
   "dependencies": {
-    "node-addon-api": "nodejs/node-addon-api#fedc8195e3a33e32a8a6b4f8b8285cdc6a104a44",
-    "setimmediate-napi": "^1.0.3",
-    "node-gyp-build": "^4.2.1"
+    "node-addon-api": "^3.0.0",
+    "node-gyp-build": "^4.2.1",
+    "setimmediate-napi": "^1.0.3"
   },
   "devDependencies": {
     "mocha": "^7.1.1",


### PR DESCRIPTION
Also sorted the list alphabetically