### PR TITLE
fix: update dependencies to the latest

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,7 @@
+"use strict"
+
+module.exports = {
+  spec: ["test/*.js"],
+  "v8-expose-gc": true,
+  recursive: true,
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 
 env:
-  - CXX=g++-4.9
+  - CXX=g++
   - CXX=clang++
 
 addons:
@@ -9,7 +9,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-4.9
+      - g++
 
 language: node_js
 
@@ -20,19 +20,18 @@ os:
 osx_image: xcode10
 
 node_js:
-  - "10"
   - "12"
-  - "14"
+  - "22"
 
 jobs:
   include:
       - os: linux
         arch: arm64
         node_js: 12
-        env: CXX=g++-4.9
+        env: CXX=g++
   exclude:
       - os: osx
-        env: CXX=g++-4.9
+        env: CXX=g++
       - os: linux
         env: CXX=clang++
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,9 @@ environment:
   matrix:
     # node.js
     - nodejs_version: "12"
+      llvm_version: "0.0"
     - nodejs_version: "22"
+      llvm_version: "0.0"
 
 platform:
   - x86
@@ -16,9 +18,11 @@ platform:
 install:
   - python -V
   - set PYTHON=python
+
   - ps: Install-Product node $env:nodejs_version $env:platform
   - node -p process.arch
   - node -p process.version
+
   - npm install --build-from-source
 
 # Post-install test scripts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ environment:
   # Test against these versions of Node.js and io.js
   matrix:
     # node.js
-    - nodejs_version: "10"
     - nodejs_version: "12"
+    - nodejs_version: "22"
 
 platform:
   - x86
@@ -33,7 +33,7 @@ after_test:
   - ps: If ($env:nodejs_version -eq "12") { npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false }
 
 # Don't actually build.
-build: off
+build: false
 
 # Set build version format here instead of in the admin panel.
 version: "{build}"
@@ -41,7 +41,7 @@ version: "{build}"
 artifacts:
   - path: prebuilds
     name: $(APPVEYOR_REPO_TAG_NAME)-win-$(PLATFORM)
-    type: zip
+    type: "Zip"
 
 deploy:
   - provider: GitHub

--- a/package.json
+++ b/package.json
@@ -24,20 +24,20 @@
   },
   "main": "lib/weak.js",
   "scripts": {
-    "test": "nyc mocha --expose-gc",
+    "test": "nyc mocha",
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi --tag-armv --tag-uv",
     "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))"
   },
   "dependencies": {
-    "node-addon-api": "^3.0.0",
-    "node-gyp-build": "^4.2.1",
-    "setimmediate-napi": "^1.0.3"
+    "node-addon-api": "^8.0.0",
+    "node-gyp-build": "^4.8.1",
+    "setimmediate-napi": "^1.0.6"
   },
   "devDependencies": {
-    "mocha": "^7.1.1",
-    "nyc": "^15.0.0",
-    "prebuildify": "^3.0.4",
+    "mocha": "^10.4.0",
+    "nyc": "^17.0.0",
+    "prebuildify": "^6.0.1",
     "prebuildify-ci": "^1.0.5"
   }
 }


### PR DESCRIPTION
This PR updates the dependencies to the latest version. This makes it possible to use this package on the latest Nodejs version.

All tests pass on Node 12 to 22:

![image](https://github.com/node-ffi-napi/weak-napi/assets/16418197/51919b53-ee12-4bbc-a2e3-0d21c0828ccd)
