### PR TITLE
feat!: Upgrade NAPI bindings to latest version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,43 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18.x', '20.x', '22.x', '24.x']
+        runner: [ubuntu-22.04, ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js ${{ matrix['node-version'] }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix['node-version'] }}
+
+      - name: Install Clang
+        if: ${{ startsWith(matrix.runner, 'ubuntu-') }}
+        uses: egor-tensin/setup-clang@v1.4
+
+      - name: Install dependencies
+        run: npm install --build-from-source
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run prebuild x64
+        if: ${{ startsWith(matrix.runner, 'ubuntu-') }}
+        shell: bash
+        run: |
+          npm run prebuild --v8_enable_pointer_compression=false \
+                           --v8_enable_31bit_smis_on_64bit_arch=false
+
+      - name: Run prebuild i32
+        if: ${{ startsWith(matrix.runner, 'ubuntu-') }}
+        shell: bash
+        run: |
+          ARCH=ia32 npm run prebuild --v8_enable_pointer_compression=false \
+                                     --v8_enable_31bit_smis_on_64bit_arch=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,10 @@ environment:
   # Test against these versions of Node.js and io.js
   matrix:
     # node.js
-    - nodejs_version: "10"
-    - nodejs_version: "12"
+    - nodejs_version: "18"
+    - nodejs_version: "20"
+    - nodejs_version: "22"
+    - nodejs_version: "24"
 
 platform:
   - x86
@@ -30,7 +32,7 @@ test_script:
   - npm test
 
 after_test:
-  - ps: If ($env:nodejs_version -eq "12") { npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false }
+  - ps: npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false
 
 # Don't actually build.
 build: off
@@ -51,4 +53,4 @@ deploy:
     auth_token: $(PREBUILD_GITHUB_TOKEN)
     on:
       appveyor_repo_tag: true
-      nodejs_version: "12"
+      nodejs_version: "24"

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))"
   },
   "dependencies": {
-    "node-addon-api": "^3.0.0",
-    "node-gyp-build": "^4.2.1",
-    "setimmediate-napi": "^1.0.3"
+    "node-addon-api": "^8.5.0",
+    "node-gyp-build": "^4.8.4",
+    "setimmediate-napi": "^1.0.6"
   },
   "devDependencies": {
-    "mocha": "^7.1.1",
-    "nyc": "^15.0.0",
-    "prebuildify": "^3.0.4",
+    "mocha": "^11.1.0",
+    "nyc": "^17.1.0",
+    "prebuildify": "^6.0.1",
     "prebuildify-ci": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "main": "lib/weak.js",
   "scripts": {
-    "test": "nyc mocha --expose-gc",
+    "test": "nyc mocha --node-option=expose-gc",
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi --tag-armv --tag-uv",
     "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))"

--- a/src/weakref.cc
+++ b/src/weakref.cc
@@ -21,7 +21,7 @@ class ObjectInfo : public ObjectWrap<ObjectInfo> {
     SetImmediate(Env(), [this]() {
       callback_.MakeCallback(Value(), {});
       callback_.Reset();
-      Reset();
+      Unref();
     });
   }
 


### PR DESCRIPTION
Bumped all dependencies to current versions and introduced a GHA workflow that exercises the code on Node 18–24 across Linux, macOS, and Windows.

The upgrade surfaced a crash on Node 20+, caused by ObjectInfo firing its callback after the wrapper had already been freed. This PR fixes that lifetime bug by using Unref() instead of Reset(), which is  more consistent with the Ref() usage in the constructor.